### PR TITLE
API version routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ end
 
 ## Usage
 
+### Validation
+
 ```elixir
 def MyAPI.MyController do
   use MyAPI.Web, :controller
@@ -25,6 +27,19 @@ def MyAPI.MyController do
   plug Versionary.Plug.VerifyHeader, versions: ["application/vnd.app.v1+json"]
 
   plug Versionary.Plug.EnsureVersion, handler: MyAPI.MyErrorHandler
+end
+```
+
+### Routing
+
+```elixir
+def MyAPI.Router do
+  use MyAPI.Web, :router
+
+  plug Versionary.Plug.VerifyHeader, versions: ["application/vnd.app.v1+json"]
+
+  plug Versionary.Plug.Forward, to: MyAPI.Router.V1,
+                                versions: ["application/vnd.app.v1+json"]
 end
 ```
 
@@ -58,3 +73,17 @@ handler will be called to process the request.
 
 Behaviour for handling requests with invalid versions. You can create your own
 custom handler with this behaviour.
+
+### [Versionary.Plug.Forward](https://hexdocs.pm/versionary/Versionary.Plug.Forward.html)
+
+Checks to see if the request has been flagged with a valid version. If the
+version is valid, the request will be forwarded to the plug provided.
+
+#### Options
+
+`to` - the plug to forward the request to
+
+`versions` - a list of strings representing versions that should be forwarded to
+the plug provided
+
+`options` - a list of options to be passed to the forwarded plug

--- a/lib/versionary/plug/ensure_version.ex
+++ b/lib/versionary/plug/ensure_version.ex
@@ -21,7 +21,7 @@ defmodule Versionary.Plug.EnsureVersion do
   If necessary you can tell the handler to only process the request for a
   specific version. If, for example, version 1 of your API has been
   decomissioned you may want to provide an error that is specific to that
-  version of the API.
+  version.
 
   ### Example
 

--- a/lib/versionary/plug/ensure_version.ex
+++ b/lib/versionary/plug/ensure_version.ex
@@ -16,7 +16,7 @@ defmodule Versionary.Plug.EnsureVersion do
   plug Versionary.Plug.EnsureVersion, handler: SomeModule
   ```
 
-  ## Handling specific versions
+  ## Handling Specific Versions
 
   If necessary you can tell the handler to only process the request for a
   specific version. If, for example, version 1 of your API has been
@@ -34,6 +34,8 @@ defmodule Versionary.Plug.EnsureVersion do
 
   The above example would halt and then handle the request by displaying a
   message informing the user that version 1 of the API has been decomissioned.
+
+  ## Default Handler
 
   As a rule of thumb, you should always provide a default handler. A default
   handler will process requests when no version or an unrecognized version

--- a/lib/versionary/plug/ensure_version.ex
+++ b/lib/versionary/plug/ensure_version.ex
@@ -31,12 +31,12 @@ defmodule Versionary.Plug.EnsureVersion do
   @doc false
   def call(conn, opts) do
     case conn.private[:validated_version] do
-      true ->
-        conn
-      false ->
+      :error ->
         handle_error(conn, opts)
       nil ->
         Logger.warn("Version has not been verified. Make sure Versionary.Plug.VerifyHeader has been called.")
+        conn
+      _ ->
         conn
     end
   end

--- a/lib/versionary/plug/ensure_version.ex
+++ b/lib/versionary/plug/ensure_version.ex
@@ -30,14 +30,16 @@ defmodule Versionary.Plug.EnsureVersion do
 
   @doc false
   def call(conn, opts) do
-    case conn.private[:validated_version] do
-      :error ->
-        handle_error(conn, opts)
-      nil ->
+    message = conn.private[:validated_version]
+
+    cond do
+      message == nil ->
         Logger.warn("Version has not been verified. Make sure Versionary.Plug.VerifyHeader has been called.")
         conn
-      _ ->
+      elem(message, 1) == :ok ->
         conn
+      true ->
+        handle_error(conn, opts)
     end
   end
 

--- a/lib/versionary/plug/ensure_version.ex
+++ b/lib/versionary/plug/ensure_version.ex
@@ -4,16 +4,52 @@ defmodule Versionary.Plug.EnsureVersion do
   on the request.
 
   If the version provided is not valid then the request will be halted and the
-  module provied to `handler` will be called. From there the handler can decide
+  module provied to `:handler` will be called. From there the handler can decide
   how to finish the request.
 
   If a handler isn't provided `Versionary.Plug.ErrorHandler.call/1` will be used
   as a default.
 
-  ## Example
+  ### Example
 
   ```
   plug Versionary.Plug.EnsureVersion, handler: SomeModule
+  ```
+
+  ## Handling specific versions
+
+  If necessary you can tell the handler to only process the request for a
+  specific version. If, for example, version 1 of your API has been
+  decomissioned you may want to provide an error that is specific to that
+  version of the API.
+
+  ### Example
+
+  ```
+  plug Versionary.Plug.VerifyHeader, versions: ["application/vnd.app.v2+json"]
+
+  plug Versionary.Plug.EnsureVersion, handler: V1DecomissionedHandler,
+                                      versions: ["application/vnd.app.v1+json"]
+  ```
+
+  The above example would halt and then handle the request by displaying a
+  message informing the user that version 1 of the API has been decomissioned.
+
+  As a rule of thumb, you should always provide a default handler. A default
+  handler will process requests when no version or an unrecognized version
+  has been supplied by the client. Default handlers provide no versions and
+  are the last handler supplied.
+
+  ### Example
+
+  ```
+  plug Versionary.Plug.VerifyHeader, versions: ["application/vnd.app.v2+json"]
+
+  plug Versionary.Plug.EnsureVersion, handler: V1DecomissionedHandler,
+                                      versions: ["application/vnd.app.v1+json"]
+
+  # default handler
+  plug Versionary.Plug.EnsureVersion, handler: DefaultHandler
   ```
   """
 
@@ -24,7 +60,8 @@ defmodule Versionary.Plug.EnsureVersion do
   @doc false
   def init(opts \\ []) do
     %{
-      handler: opts[:handler] || Versionary.Plug.ErrorHandler
+      handler: opts[:handler] || Versionary.Plug.ErrorHandler,
+      versions: opts[:versions]
     }
   end
 
@@ -46,10 +83,17 @@ defmodule Versionary.Plug.EnsureVersion do
   # private
 
   defp handle_error(conn, opts) do
-    handler_opt = opts[:handler]
+    {version, :error} = conn.private[:validated_version]
+    versions_opt = opts[:versions]
 
-    conn = conn |> halt
+    if !is_list(versions_opt) || version in versions_opt do
+      handler_opt = opts[:handler]
 
-    apply(handler_opt, :call, [conn])
+      conn = conn |> halt
+
+      apply(handler_opt, :call, [conn])
+    else
+      conn
+    end
   end
 end

--- a/lib/versionary/plug/ensure_version.ex
+++ b/lib/versionary/plug/ensure_version.ex
@@ -32,14 +32,14 @@ defmodule Versionary.Plug.EnsureVersion do
   def call(conn, opts) do
     message = conn.private[:validated_version]
 
-    cond do
-      message == nil ->
+    case message do
+      nil ->
         Logger.warn("Version has not been verified. Make sure Versionary.Plug.VerifyHeader has been called.")
         conn
-      elem(message, 1) == :ok ->
-        conn
-      true ->
+      {_, :error} ->
         handle_error(conn, opts)
+      {_, :ok} ->
+        conn
     end
   end
 

--- a/lib/versionary/plug/ensure_version.ex
+++ b/lib/versionary/plug/ensure_version.ex
@@ -30,7 +30,7 @@ defmodule Versionary.Plug.EnsureVersion do
 
   @doc false
   def call(conn, opts) do
-    case conn.private[:version_verified] do
+    case conn.private[:validated_version] do
       true ->
         conn
       false ->

--- a/lib/versionary/plug/forward.ex
+++ b/lib/versionary/plug/forward.ex
@@ -1,0 +1,52 @@
+defmodule Versionary.Plug.Forward do
+  @moduledoc """
+  This plug will forward requests with a valid version to the plug provided.
+
+  ### Example
+
+  ```
+  plug Versionary.Plug.Forward, to: MyAPI.Router.V1,
+                                versions: ["application/vnd.app.v1+json"]
+  ```
+  """
+
+  import Plug.Conn
+
+  @doc false
+  def init(opts) do
+    %{
+      options: opts[:options] || [],
+      to: opts[:to],
+      versions: opts[:versions]
+    }
+  end
+
+  @doc false
+  def call(conn, opts) do
+    message = conn.private[:validated_version]
+
+    case message do
+      {_, :ok} ->
+        handle_forward(conn, opts)
+      _ ->
+        conn
+    end
+  end
+
+  # private
+
+  defp handle_forward(conn, opts) do
+    {version, :ok} = conn.private[:validated_version]
+    to_opts = opts[:to]
+    versions_opt = opts[:versions]
+    options_opt = opts[:options]
+
+    if is_list(versions_opt) && version in versions_opt do
+      conn
+      |> to_opts.call(to_opts.init(options_opt))
+      |> halt
+    else
+      conn
+    end
+  end
+end

--- a/lib/versionary/plug/verify_header.ex
+++ b/lib/versionary/plug/verify_header.ex
@@ -52,8 +52,10 @@ defmodule Versionary.Plug.VerifyHeader do
 
   defp validate_version(conn, opts) do
     version = get_version(conn, opts)
-    verified = Enum.member?(opts[:versions], version)
 
-    put_private(conn, :validated_version, verified)
+    case Enum.member?(opts[:versions], version) do
+      false -> put_private(conn, :validated_version, :error)
+      true  -> put_private(conn, :validated_version, version)
+    end
   end
 end

--- a/lib/versionary/plug/verify_header.ex
+++ b/lib/versionary/plug/verify_header.ex
@@ -38,7 +38,7 @@ defmodule Versionary.Plug.VerifyHeader do
   @doc false
   def call(conn, opts) do
     conn
-    |> verify_version(opts)
+    |> validate_version(opts)
   end
 
   # private
@@ -50,10 +50,10 @@ defmodule Versionary.Plug.VerifyHeader do
     end
   end
 
-  defp verify_version(conn, opts) do
+  defp validate_version(conn, opts) do
     version = get_version(conn, opts)
     verified = Enum.member?(opts[:versions], version)
 
-    put_private(conn, :version_verified, verified)
+    put_private(conn, :validated_version, verified)
   end
 end

--- a/lib/versionary/plug/verify_header.ex
+++ b/lib/versionary/plug/verify_header.ex
@@ -54,8 +54,8 @@ defmodule Versionary.Plug.VerifyHeader do
     version = get_version(conn, opts)
 
     case Enum.member?(opts[:versions], version) do
-      false -> put_private(conn, :validated_version, :error)
-      true  -> put_private(conn, :validated_version, version)
+      false -> put_private(conn, :validated_version, {version, :error})
+      true  -> put_private(conn, :validated_version, {version, :ok})
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -40,10 +40,13 @@ defmodule Versionary.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [{:plug, "~> 1.3"},
-     # dev
-     {:ex_doc, ">= 0.0.0", only: :dev},
-     # test
-     {:excoveralls, "~> 0.6.0", only: :test, runtime: false}]
+      # dev
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      # test
+      {:excoveralls, "~> 0.6.0", only: :test, runtime: false},
+      # dev, test
+      {:credo, "~> 0.7", only: [:dev, :test]}
+    ]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"certifi": {:hex, :certifi, "1.0.0", "1c787a85b1855ba354f0b8920392c19aa1d06b0ee1362f9141279620a5be2039", [:rebar3], []},
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
+  "certifi": {:hex, :certifi, "1.0.0", "1c787a85b1855ba354f0b8920392c19aa1d06b0ee1362f9141279620a5be2039", [:rebar3], []},
+  "credo": {:hex, :credo, "0.7.0", "be777315dd6233edba403625af9fb109394277bc408c0b9df501736b9328466d", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
   "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
   "excoveralls": {:hex, :excoveralls, "0.6.2", "0e993d096f1fbb6e70a3daced5c89aac066bda6bce57829622aa2d1e2b338cfb", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},

--- a/test/versionary/plug/ensure_version_test.exs
+++ b/test/versionary/plug/ensure_version_test.exs
@@ -31,13 +31,13 @@ defmodule Versionary.Plug.EnsureVersionTest do
   test "request does not halt if version is verified" do
     conn =
       conn(:get, "/")
-      |> put_private(:validated_version, true)
+      |> put_private(:validated_version, "application/vnd.app.v1+json")
       |> EnsureVersion.call(@opts)
 
     refute conn.halted
   end
 
-  test "request does not halt of verification has not happened" do
+  test "request does not halt if verification has not happened" do
     conn =
       conn(:get, "/")
       |> EnsureVersion.call(@opts)
@@ -54,7 +54,7 @@ defmodule Versionary.Plug.EnsureVersionTest do
   test "request does halt if version is not verified" do
     conn =
       conn(:get, "/")
-      |> put_private(:validated_version, false)
+      |> put_private(:validated_version, :error)
       |> EnsureVersion.call(@opts)
 
     assert conn.halted
@@ -63,7 +63,7 @@ defmodule Versionary.Plug.EnsureVersionTest do
   test "handler is called when version is not verified" do
     conn =
       conn(:get, "/")
-      |> put_private(:validated_version, false)
+      |> put_private(:validated_version, :error)
       |> EnsureVersion.call(@opts)
 
     assert conn.assigns[:versionary_spec] == :not_supported

--- a/test/versionary/plug/ensure_version_test.exs
+++ b/test/versionary/plug/ensure_version_test.exs
@@ -31,7 +31,7 @@ defmodule Versionary.Plug.EnsureVersionTest do
   test "request does not halt if version is verified" do
     conn =
       conn(:get, "/")
-      |> put_private(:version_verified, true)
+      |> put_private(:validated_version, true)
       |> EnsureVersion.call(@opts)
 
     refute conn.halted
@@ -54,7 +54,7 @@ defmodule Versionary.Plug.EnsureVersionTest do
   test "request does halt if version is not verified" do
     conn =
       conn(:get, "/")
-      |> put_private(:version_verified, false)
+      |> put_private(:validated_version, false)
       |> EnsureVersion.call(@opts)
 
     assert conn.halted
@@ -63,7 +63,7 @@ defmodule Versionary.Plug.EnsureVersionTest do
   test "handler is called when version is not verified" do
     conn =
       conn(:get, "/")
-      |> put_private(:version_verified, false)
+      |> put_private(:validated_version, false)
       |> EnsureVersion.call(@opts)
 
     assert conn.assigns[:versionary_spec] == :not_supported

--- a/test/versionary/plug/ensure_version_test.exs
+++ b/test/versionary/plug/ensure_version_test.exs
@@ -108,7 +108,7 @@ defmodule Versionary.Plug.EnsureVersionTest do
       assert conn.assigns[:versionary_spec] == :test_handler_1
     end
 
-    test "handle is called for a specific version" do
+    test "handler is called for a specific version" do
       conn =
         conn(:get, "/")
         |> Plug.Conn.put_req_header("accept", @v2)

--- a/test/versionary/plug/ensure_version_test.exs
+++ b/test/versionary/plug/ensure_version_test.exs
@@ -5,6 +5,7 @@ defmodule Versionary.Plug.EnsureVersionTest do
   import ExUnit.CaptureLog
 
   alias Versionary.Plug.EnsureVersion
+  alias Versionary.Plug.VerifyHeader
 
   defmodule TestHandler do
     @moduledoc false
@@ -16,56 +17,66 @@ defmodule Versionary.Plug.EnsureVersionTest do
     end
   end
 
+  @v1 "application/vnd.app.v1+json"
+  @v2 "application/vnd.app.v2+json"
+
   @opts EnsureVersion.init([handler: TestHandler])
 
-  test "init/1 sets the handler option to the module that's passed in" do
-    assert @opts[:handler] == TestHandler
+  describe "init/1" do
+    test "sets the handler option to the module that's passed in" do
+      assert @opts[:handler] == TestHandler
+    end
+
+    test "sets the default handler if a value is not passed in" do
+      opts = EnsureVersion.init()
+
+      assert opts[:handler] == Versionary.Plug.ErrorHandler
+    end
   end
 
-  test "init/1 sets the default handler if a value is not passed in" do
-    opts = EnsureVersion.init()
+  describe "call/2" do
+    test "does not halt if version is valid" do
+      conn =
+        conn(:get, "/")
+        |> Plug.Conn.put_req_header("accept", @v1)
+        |> VerifyHeader.call(VerifyHeader.init(versions: [@v1]))
+        |> EnsureVersion.call(@opts)
 
-    assert opts[:handler] == Versionary.Plug.ErrorHandler
-  end
+      refute conn.halted
+    end
 
-  test "request does not halt if version is verified" do
-    conn =
-      conn(:get, "/")
-      |> put_private(:validated_version, "application/vnd.app.v1+json")
-      |> EnsureVersion.call(@opts)
+    test "does not halt if validation has not happened" do
+      conn =
+        conn(:get, "/")
+        |> EnsureVersion.call(@opts)
 
-    refute conn.halted
-  end
+      refute conn.halted
+    end
 
-  test "request does not halt if verification has not happened" do
-    conn =
-      conn(:get, "/")
-      |> EnsureVersion.call(@opts)
+    test "warning is logged if validation has not happened" do
+      assert capture_log([level: :warn], fn ->
+        conn(:get, "/") |> EnsureVersion.call(@opts)
+      end) =~ "Version has not been verified."
+    end
 
-    refute conn.halted
-  end
+    test "does halt if version is invalid" do
+      conn =
+        conn(:get, "/")
+        |> Plug.Conn.put_req_header("accept", @v2)
+        |> VerifyHeader.call(VerifyHeader.init(versions: [@v1]))
+        |> EnsureVersion.call(@opts)
 
-  test "warning is logged if verification has not happened" do
-    assert capture_log([level: :warn], fn ->
-      conn(:get, "/") |> EnsureVersion.call(@opts)
-    end) =~ "Version has not been verified."
-  end
+      assert conn.halted
+    end
 
-  test "request does halt if version is not verified" do
-    conn =
-      conn(:get, "/")
-      |> put_private(:validated_version, :error)
-      |> EnsureVersion.call(@opts)
+    test "handler is called when version is not verified" do
+      conn =
+        conn(:get, "/")
+        |> Plug.Conn.put_req_header("accept", @v2)
+        |> VerifyHeader.call(VerifyHeader.init(versions: [@v1]))
+        |> EnsureVersion.call(@opts)
 
-    assert conn.halted
-  end
-
-  test "handler is called when version is not verified" do
-    conn =
-      conn(:get, "/")
-      |> put_private(:validated_version, :error)
-      |> EnsureVersion.call(@opts)
-
-    assert conn.assigns[:versionary_spec] == :not_supported
+      assert conn.assigns[:versionary_spec] == :not_supported
+    end
   end
 end

--- a/test/versionary/plug/forward_test.exs
+++ b/test/versionary/plug/forward_test.exs
@@ -102,7 +102,7 @@ defmodule Versionary.Plug.ForwardTest do
       conn(:get, "/")
       |> put_req_header("accept", @v1)
       |> VerifyHeader.call(VerifyHeader.init([versions: [@v1]]))
-      |> Forward.call(Forward.init([to: TestRouter2, versions: [@v2]]))
+      |> Forward.call(Forward.init([to: TestRouter2, versions: [@v2], options: []]))
 
     assert conn.assigns[:versionary_spec] == nil
   end

--- a/test/versionary/plug/forward_test.exs
+++ b/test/versionary/plug/forward_test.exs
@@ -1,0 +1,109 @@
+defmodule Versionary.Plug.ForwardTest do
+  use ExUnit.Case
+  use Plug.Test
+
+  alias Versionary.Plug.Forward
+  alias Versionary.Plug.VerifyHeader
+
+  defmodule TestRouter1 do
+    @moduledoc false
+
+    use Plug.Router
+
+    plug Versionary.Plug.VerifyHeader, versions: ["application/vnd.app.v1+json"]
+
+    plug Versionary.Plug.Forward, to: Versionary.Plug.ForwardTest.TestRouter2,
+                                  versions: ["application/vnd.app.v1+json"]
+
+    plug :match
+    plug :dispatch
+
+    get "/" do
+      conn
+      |> assign(:versionary_spec, :test_router_1)
+      |> send_resp(200, "OK")
+    end
+
+    match _, do: send_resp(conn, 404, "Not Found")
+  end
+
+  defmodule TestRouter2 do
+    @moduledoc false
+
+    use Plug.Router
+
+    plug :match
+    plug :dispatch
+
+    get "/" do
+      conn
+      |> assign(:versionary_spec, :test_router_2)
+      |> send_resp(200, "OK")
+    end
+
+    match _, do: send_resp(conn, 404, "Not Found")
+  end
+
+  @v1 "application/vnd.app.v1+json"
+  @v2 "application/vnd.app.v2+json"
+
+  describe "call/2" do
+    test "forwards request to provieded plug" do
+      conn =
+        conn(:get, "/")
+        |> put_req_header("accept", @v1)
+        |> TestRouter1.call(TestRouter1.init([]))
+
+      assert conn.assigns[:versionary_spec] == :test_router_2
+    end
+
+    test "prevents the original router from finishing" do
+      conn =
+        conn(:get, "/")
+        |> put_req_header("accept", @v1)
+        |> TestRouter1.call(TestRouter1.init([]))
+
+      refute conn.assigns[:versionary_spec] == :test_router_1
+    end
+
+    test "forwards if header is validated" do
+      conn =
+        conn(:get, "/")
+        |> put_req_header("accept", @v1)
+        |> VerifyHeader.call(VerifyHeader.init([versions: [@v1]]))
+        |> Forward.call(Forward.init([to: TestRouter2, versions: [@v1]]))
+
+      assert conn.assigns[:versionary_spec] == :test_router_2
+    end
+
+    test "does not forward if header is not valid" do
+      conn =
+        conn(:get, "/")
+        |> put_req_header("accept", @v2)
+        |> VerifyHeader.call(VerifyHeader.init([versions: [@v1]]))
+        |> Forward.call(Forward.init([to: TestRouter2, versions: [@v1]]))
+
+      assert conn.assigns[:versionary_spec] == nil
+    end
+  end
+
+  test "forwards if versions match" do
+    conn =
+      conn(:get, "/")
+      |> put_req_header("accept", @v1)
+      |> VerifyHeader.call(VerifyHeader.init([versions: [@v1]]))
+      |> Forward.call(Forward.init([to: TestRouter2, versions: [@v1]]))
+
+    assert conn.assigns[:versionary_spec] == :test_router_2
+  end
+
+  test "does not forward if versions do not match" do
+    conn =
+      conn(:get, "/")
+      |> put_req_header("accept", @v1)
+      |> VerifyHeader.call(VerifyHeader.init([versions: [@v1]]))
+      |> Forward.call(Forward.init([to: TestRouter2, versions: [@v2]]))
+
+    assert conn.assigns[:versionary_spec] == nil
+  end
+end

--- a/test/versionary/plug/verify_header_test.exs
+++ b/test/versionary/plug/verify_header_test.exs
@@ -26,7 +26,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
   test "verification fails if version is not present" do
     conn = conn(:get, "/") |> VerifyHeader.call(@opts1)
 
-    assert conn.private[:version_verified] == false
+    assert conn.private[:validated_version] == false
   end
 
   test "verification fails if version is incorrect" do
@@ -35,7 +35,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("accept", @v2)
       |> VerifyHeader.call(@opts1)
 
-    assert conn.private[:version_verified] == false
+    assert conn.private[:validated_version] == false
   end
 
   test "verification fails if header is incorrect" do
@@ -44,7 +44,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("accept", @v1)
       |> VerifyHeader.call(@opts2)
 
-    assert conn.private[:version_verified] == false
+    assert conn.private[:validated_version] == false
   end
 
   test "verification succeeds if version matches" do
@@ -53,7 +53,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("accept", @v1)
       |> VerifyHeader.call(@opts1)
 
-      assert conn.private[:version_verified] == true
+      assert conn.private[:validated_version] == true
   end
 
   test "verification succeeds if header and version match" do
@@ -62,7 +62,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("x-version", @v1)
       |> VerifyHeader.call(@opts2)
 
-      assert conn.private[:version_verified] == true
+      assert conn.private[:validated_version] == true
   end
 
   test "verification succeeds if at least one version matches" do
@@ -71,6 +71,6 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("accept", @v1)
       |> VerifyHeader.call(@opts3)
 
-      assert conn.private[:version_verified] == true
+      assert conn.private[:validated_version] == true
   end
 end

--- a/test/versionary/plug/verify_header_test.exs
+++ b/test/versionary/plug/verify_header_test.exs
@@ -26,7 +26,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
   test "verification fails if version is not present" do
     conn = conn(:get, "/") |> VerifyHeader.call(@opts1)
 
-    assert conn.private[:validated_version] == :error
+    assert conn.private[:validated_version] == {nil, :error}
   end
 
   test "verification fails if version is incorrect" do
@@ -35,7 +35,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("accept", @v2)
       |> VerifyHeader.call(@opts1)
 
-    assert conn.private[:validated_version] == :error
+    assert conn.private[:validated_version] == {@v2, :error}
   end
 
   test "verification fails if header is incorrect" do
@@ -44,7 +44,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("accept", @v1)
       |> VerifyHeader.call(@opts2)
 
-    assert conn.private[:validated_version] == :error
+    assert conn.private[:validated_version] == {nil, :error}
   end
 
   test "verification succeeds if version matches" do
@@ -53,7 +53,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("accept", @v1)
       |> VerifyHeader.call(@opts1)
 
-      assert conn.private[:validated_version] == @v1
+      assert conn.private[:validated_version] == {@v1, :ok}
   end
 
   test "verification succeeds if header and version match" do
@@ -62,7 +62,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("x-version", @v1)
       |> VerifyHeader.call(@opts2)
 
-      assert conn.private[:validated_version] == @v1
+      assert conn.private[:validated_version] == {@v1, :ok}
   end
 
   test "verification succeeds if at least one version matches" do
@@ -71,6 +71,6 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("accept", @v1)
       |> VerifyHeader.call(@opts3)
 
-      assert conn.private[:validated_version] == @v1
+      assert conn.private[:validated_version] == {@v1, :ok}
   end
 end

--- a/test/versionary/plug/verify_header_test.exs
+++ b/test/versionary/plug/verify_header_test.exs
@@ -26,7 +26,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
   test "verification fails if version is not present" do
     conn = conn(:get, "/") |> VerifyHeader.call(@opts1)
 
-    assert conn.private[:validated_version] == false
+    assert conn.private[:validated_version] == :error
   end
 
   test "verification fails if version is incorrect" do
@@ -35,7 +35,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("accept", @v2)
       |> VerifyHeader.call(@opts1)
 
-    assert conn.private[:validated_version] == false
+    assert conn.private[:validated_version] == :error
   end
 
   test "verification fails if header is incorrect" do
@@ -44,7 +44,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("accept", @v1)
       |> VerifyHeader.call(@opts2)
 
-    assert conn.private[:validated_version] == false
+    assert conn.private[:validated_version] == :error
   end
 
   test "verification succeeds if version matches" do
@@ -53,7 +53,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("accept", @v1)
       |> VerifyHeader.call(@opts1)
 
-      assert conn.private[:validated_version] == true
+      assert conn.private[:validated_version] == @v1
   end
 
   test "verification succeeds if header and version match" do
@@ -62,7 +62,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("x-version", @v1)
       |> VerifyHeader.call(@opts2)
 
-      assert conn.private[:validated_version] == true
+      assert conn.private[:validated_version] == @v1
   end
 
   test "verification succeeds if at least one version matches" do
@@ -71,6 +71,6 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("accept", @v1)
       |> VerifyHeader.call(@opts3)
 
-      assert conn.private[:validated_version] == true
+      assert conn.private[:validated_version] == @v1
   end
 end


### PR DESCRIPTION
Added `Versionary.Plug.Forward` to forward a request to a different plug, router, endpoint, etc. when a specific version is passed in. This will be useful for having separate routers for each version of an API.