### PR TITLE
Add a way to support multiple versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ defmodule MyAPI.Router do
 
     get "/my_controllers", MyController, :index
   end
+
 end
 ```
 
@@ -113,3 +114,20 @@ handler will be called to process the request.
 
 Behaviour for handling requests with invalid versions. You can create your own
 custom handler with this behaviour.
+
+# Development
+
+## Run tests
+
+Before running the test make sure all dependencies are installed, to do that just
+run the following command
+
+```bash
+$ mix deps.get
+```
+
+Then to run the test run this command
+
+```bash
+$ mix tests
+```

--- a/test/versionary/plug/verify_header_test.exs
+++ b/test/versionary/plug/verify_header_test.exs
@@ -57,6 +57,24 @@ defmodule Versionary.Plug.VerifyHeaderTest do
     assert conn.private[:version_verified] == false
   end
 
+  test "does not store version if verification fails" do
+    conn =
+      conn(:get, "/")
+      |> put_req_header("accept", @v1)
+      |> VerifyHeader.call(@opts2)
+
+    assert conn.private[:version] == nil
+  end
+
+  test "does not store raw version if verification fails" do
+    conn =
+      conn(:get, "/")
+      |> put_req_header("accept", @v1)
+      |> VerifyHeader.call(@opts2)
+
+    assert conn.private[:raw_version] == nil
+  end
+
   test "verification succeeds if version matches" do
     conn =
       conn(:get, "/")
@@ -82,6 +100,24 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> VerifyHeader.call(@opts3)
 
       assert conn.private[:version_verified] == true
+  end
+
+  test "store used version if verification succeeds" do
+    conn =
+      conn(:get, "/")
+      |> put_req_header("accept", @v1)
+      |> VerifyHeader.call(@opts3)
+
+    assert conn.private[:version] == [:v1]
+  end
+
+  test "store used raw version if verification succeeds" do
+    conn =
+      conn(:get, "/")
+      |> put_req_header("accept", @v1)
+      |> VerifyHeader.call(@opts3)
+
+    assert conn.private[:raw_version] == @v1
   end
 
   test "verification succeeds if at least one mime matches" do


### PR DESCRIPTION
Store the version used on a private in the connection to allow render
different views based on the selected version. Remove a deprecation
warning on MIME types.