### PR TITLE
Fix multiple mime types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ erl_crash.dump
 
 # Ignore macOS directory config.
 .DS_Store
+
+.elixir_ls

--- a/config/test.exs
+++ b/config/test.exs
@@ -3,5 +3,6 @@
 use Mix.Config
 
 config :mime, :types, %{
-  "application/vnd.app.v1+json" => [:v1]
+  "application/vnd.app.v1+json" => [:v1],
+  "application/vnd.app.v2+json" => [:v2]
 }

--- a/lib/versionary/plug/verify_header.ex
+++ b/lib/versionary/plug/verify_header.ex
@@ -124,13 +124,13 @@ defmodule Versionary.Plug.VerifyHeader do
   defp get_mime_versions(%{accepts: accepts}), do: do_get_mime_versions(accepts)
   defp get_mime_versions(_opts), do: []
 
-  defp do_get_mime_versions([h|t]), do: [MIME.type(h)] ++ get_mime_versions(t)
+  defp do_get_mime_versions([h | t]), do: [MIME.type(h)] ++ do_get_mime_versions(t)
   defp do_get_mime_versions([]), do: []
   defp do_get_mime_versions(nil), do: []
 
   defp get_req_version(conn, opts) do
     case get_req_header(conn, opts[:header]) do
-      []        -> nil
+      [] -> nil
       [version] -> version
     end
   end

--- a/test/versionary/plug/verify_header_test.exs
+++ b/test/versionary/plug/verify_header_test.exs
@@ -7,10 +7,10 @@ defmodule Versionary.Plug.VerifyHeaderTest do
   @v1 "application/vnd.app.v1+json"
   @v2 "application/vnd.app.v2+json"
 
-  @opts1 VerifyHeader.init([versions: [@v1]])
-  @opts2 VerifyHeader.init([header: "x-version", versions: [@v1]])
-  @opts3 VerifyHeader.init([versions: [@v1, @v2]])
-  @opts4 VerifyHeader.init([accepts: [:v1]])
+  @opts1 VerifyHeader.init(versions: [@v1])
+  @opts2 VerifyHeader.init(header: "x-version", versions: [@v1])
+  @opts3 VerifyHeader.init(versions: [@v1, @v2])
+  @opts4 VerifyHeader.init(accepts: [:v1, :v2])
 
   test "init/1 sets the header option to the value passed in" do
     assert @opts2[:header] == "x-version"
@@ -25,7 +25,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
   end
 
   test "verification fails if version is not present" do
-    conn =  VerifyHeader.call(conn(:get, "/"), @opts1)
+    conn = VerifyHeader.call(conn(:get, "/"), @opts1)
 
     assert conn.private[:version_verified] == false
   end
@@ -81,7 +81,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("accept", @v1)
       |> VerifyHeader.call(@opts1)
 
-      assert conn.private[:version_verified] == true
+    assert conn.private[:version_verified] == true
   end
 
   test "verification succeeds if header and version match" do
@@ -90,7 +90,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("x-version", @v1)
       |> VerifyHeader.call(@opts2)
 
-      assert conn.private[:version_verified] == true
+    assert conn.private[:version_verified] == true
   end
 
   test "verification succeeds if at least one version matches" do
@@ -99,7 +99,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("accept", @v1)
       |> VerifyHeader.call(@opts3)
 
-      assert conn.private[:version_verified] == true
+    assert conn.private[:version_verified] == true
   end
 
   test "store used version if verification succeeds" do
@@ -126,6 +126,15 @@ defmodule Versionary.Plug.VerifyHeaderTest do
       |> put_req_header("accept", @v1)
       |> VerifyHeader.call(@opts4)
 
-      assert conn.private[:version_verified] == true
+    assert conn.private[:version_verified] == true
+  end
+
+  test "verification succeeds if at least one mime matches, accept header v2" do
+    conn =
+      conn(:get, "/")
+      |> put_req_header("accept", @v2)
+      |> VerifyHeader.call(@opts4)
+
+    assert conn.private[:version_verified] == true
   end
 end

--- a/test/versionary/plug/verify_header_test.exs
+++ b/test/versionary/plug/verify_header_test.exs
@@ -6,6 +6,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
 
   @v1 "application/vnd.app.v1+json"
   @v2 "application/vnd.app.v2+json"
+  @v3 "application/vnd.app.v3+json"
 
   @opts1 VerifyHeader.init(versions: [@v1])
   @opts2 VerifyHeader.init(header: "x-version", versions: [@v1])
@@ -42,7 +43,7 @@ defmodule Versionary.Plug.VerifyHeaderTest do
   test "verification fails if mime is incorrect" do
     conn =
       conn(:get, "/")
-      |> put_req_header("accept", @v2)
+      |> put_req_header("accept", @v3)
       |> VerifyHeader.call(@opts4)
 
     assert conn.private[:version_verified] == false


### PR DESCRIPTION
The problem occurred when I tried to use multiple mime types [:v1, :v2]. The VerifyHeader plug would always just verify the first mime type in the list. 

The fix is really simple, just calling the _do_get_mime_version(t)_ function instead of _get_mime_versions(t)_. 