### PR TITLE
Fix getting valid accept header when using multiple values

### DIFF
--- a/lib/versionary/plug/verify_header.ex
+++ b/lib/versionary/plug/verify_header.ex
@@ -136,6 +136,7 @@ defmodule Versionary.Plug.VerifyHeader do
   defp get_req_version(headers, opts) when is_binary(headers) do
     String.split(headers, ",")
     |> Enum.map(&String.split(&1, ";") |> hd)
+    |> Enum.map(&String.trim/1)
     |> get_req_version(opts)
   end
   defp get_req_version([head | tail], opts) do

--- a/test/versionary/plug/verify_header_test.exs
+++ b/test/versionary/plug/verify_header_test.exs
@@ -4,9 +4,10 @@ defmodule Versionary.Plug.VerifyHeaderTest do
 
   alias Versionary.Plug.VerifyHeader
 
-  @v1 "application/vnd.app.v1+json"
-  @v2 "application/vnd.app.v2+json"
-  @v3 "application/vnd.app.v3+json"
+  @v1    "application/vnd.app.v1+json"
+  @v2    "application/vnd.app.v2+json"
+  @v3    "application/vnd.app.v3+json"
+  @mixed "application/vnd.app.v1+json,application/json;q=0.9"
 
   @opts1 VerifyHeader.init(versions: [@v1])
   @opts2 VerifyHeader.init(header: "x-version", versions: [@v1])
@@ -138,4 +139,23 @@ defmodule Versionary.Plug.VerifyHeaderTest do
 
     assert conn.private[:version_verified] == true
   end
+
+  test "verification succeeds when using mixed accept headers, and at least one mime matches" do
+    conn =
+      conn(:get, "/")
+      |> put_req_header("accept", @mixed)
+      |> VerifyHeader.call(@opts4)
+
+    assert conn.private[:version_verified] == true
+  end
+
+  test "verification succeeds when using mixed x-version headers, and at least one mime matches" do
+    conn =
+      conn(:get, "/")
+      |> put_req_header("x-version", @mixed)
+      |> VerifyHeader.call(@opts2)
+
+    assert conn.private[:version_verified] == true
+  end
+
 end


### PR DESCRIPTION
Fixes an issue where we cannot get the correct value when using more than one
accept value.

The following example would fail because it cannot extract the valid accept value from the string.

```elixir
opts = VerifyHeader.init(accepts: [:v1])

conn
|> put_req_header("accept", "application/vnd.api+json,application/vnd.app.v1+json")
|> VerifyHeader.call(opts)
```

Since ie. [JSON:API](https://jsonapi.org/format/#content-negotiation-clients) requires a certain Accept header to be set, we need to be able to extract the one we care about for the versioning scheme.