### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,14 @@
 # The directory Mix will write compiled artifacts to.
-/_build
+/_build/
 
 # If you run "mix test --cover", coverage assets end up here.
-/cover
+/cover/
 
 # The directory Mix downloads your dependencies sources to.
-/deps
+/deps/
 
-# Where 3rd-party dependencies like ExDoc output generated docs.
-/doc
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
 
 # Ignore .fetch files in case you like to edit your project deps locally.
 /.fetch
@@ -19,7 +19,11 @@ erl_crash.dump
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
 
+# Ignore package tarball (built via "mix hex.build").
+versionary-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/
+
 # Ignore macOS directory config.
 .DS_Store
-
-.elixir_ls

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-MIT License
+# MIT License
 
 Copyright (c) 2017 Sticksnleaves
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,26 @@
 # Versionary
 
-Add versioning to your Elixir Plug and Phoenix built API's
+Add versioning to your Elixir Plug and Phoenix built API's.
 
-[![ci](https://github.com/sticksnleaves/versionary/actions/workflows/ci.yaml/badge.svg)](https://github.com/sticksnleaves/versionary/actions/workflows/ci.yaml)
+[![CI](https://github.com/sticksnleaves/versionary/actions/workflows/ci.yaml/badge.svg)](https://github.com/sticksnleaves/versionary/actions/workflows/ci.yaml)
 [![Coverage Status](https://coveralls.io/repos/github/sticksnleaves/versionary/badge.svg?branch=master)](https://coveralls.io/github/sticksnleaves/versionary?branch=master)
+[![Module Version](https://img.shields.io/hexpm/v/versionary.svg)](https://hex.pm/packages/versionary)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/versionary/)
+[![Total Download](https://img.shields.io/hexpm/dt/versionary.svg)](https://hex.pm/packages/versionary)
+[![License](https://img.shields.io/hexpm/l/versionary.svg)](https://github.com/sticksnleaves/versionary/blob/master/LICENSE.md)
+[![Last Updated](https://img.shields.io/github/last-commit/sticksnleaves/versionary.svg)](https://github.com/sticksnleaves/versionary/commits/master)
+
 
 ## Installation
 
-The package can be installed by adding `versionary` to your list of dependencies
+The package can be installed by adding `:versionary` to your list of dependencies
 in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:versionary, "~> 0.3"}]
+  [
+    {:versionary, "~> 0.3"}
+  ]
 end
 ```
 
@@ -36,14 +44,14 @@ end
 It's possible to verify versions against configured MIME types. If multiple MIME
 types are passed and at least one matches the version will be considered valid.
 
-```
+```elixir
 config :mime, :types, %{
   "application/vnd.app.v1+json" => [:v1],
   "application/vnd.app.v2+json" => [:v2]
 }
 ```
 
-```
+```elixir
 plug Versionary.Plug.VerifyHeader, accepts: [:v1, :v2]
 ```
 
@@ -141,3 +149,9 @@ handler will be called to process the request.
 
 Behaviour for handling requests with invalid versions. You can create your own
 custom handler with this behaviour.
+
+# Copyright and License
+
+Copyright (c) 2017 Sticksnleaves
+
+This library is licensed under the [MIT license](./LICENSE.md).

--- a/lib/versionary/plug/ensure_version.ex
+++ b/lib/versionary/plug/ensure_version.ex
@@ -4,7 +4,7 @@ defmodule Versionary.Plug.EnsureVersion do
   on the request.
 
   If the version provided is not valid then the request will be halted and the
-  module provied to `handler` will be called. From there the handler can decide
+  module provided to `handler` will be called. From there the handler can decide
   how to finish the request.
 
   If a handler isn't provided `Versionary.Plug.ErrorHandler.call/1` will be used
@@ -12,9 +12,10 @@ defmodule Versionary.Plug.EnsureVersion do
 
   ## Example
 
-  ```
+  ```elixir
   plug Versionary.Plug.EnsureVersion, handler: SomeModule
   ```
+
   """
 
   require Logger

--- a/lib/versionary/plug/handler.ex
+++ b/lib/versionary/plug/handler.ex
@@ -16,7 +16,7 @@ defmodule Versionary.Plug.Handler do
 
   ## Example
 
-  ```
+  ```elixir
   defmodule MyAPI.MyErrorHandler do
     @behaviour Versionary.Plug.Handler
 

--- a/lib/versionary/plug/verify_header.ex
+++ b/lib/versionary/plug/verify_header.ex
@@ -12,27 +12,26 @@ defmodule Versionary.Plug.VerifyHeader do
 
   ## Options
 
-  * `:versions` - a list of strings representing valid versions. If at least one
-                  of the provided versions is valid then the request is
-                  considered valid.
+  * `:versions` - a list of strings representing valid versions. If at least
+    one of the provided versions is valid then the request is considered valid.
+
   * `:accepts` - a list of strings or atoms representing versions registered as
-                 MIME types. If at least one of the registered versions is valid
-                 then the request is considered valid.
+    MIME types. If at least one of the registered versions is valid then the
+    request is considered valid.
+
   * `:header` - the header used to provide the requested version (Default:
-                `Accept`)
+    `Accept`)
 
-  ## Usage
+  ## Example
 
-  ```
-  plug Versionary.Plug.VerifyHeader, versions: ["application/vnd.app.v1+json"]
-  ```
+      plug Versionary.Plug.VerifyHeader, versions: ["application/vnd.app.v1+json"]
 
   ## Multiple Versions
 
   You may pass multiple version strings to the `:versions` option. If at least
   one version matches the request will be considered valid.
 
-  ```
+  ```elixir
   plug Versionary.Plug.VerifyHeader, versions: ["application/vnd.app.v1+json",
                                                 "application/vnd.app.v2+json"]
   ```
@@ -43,13 +42,13 @@ defmodule Versionary.Plug.VerifyHeader do
   multiple MIME types are passed and at least one matches the version will be
   considered valid.
 
-  ```
+  ```elixir
   config :mime, :types, %{
     "application/vnd.app.v1+json" => [:v1]
   }
   ```
 
-  ```
+  ```elixir
   plug Versionary.Plug.VerifyHeader, accepts: [:v1]
   ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,25 +1,30 @@
 defmodule Versionary.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/sticksnleaves/versionary"
+  @version "0.4.0"
+
   def project do
-    [app: :versionary,
-     name: "Versionary",
-     description: "Elixir plug for handling API versioning",
-     version: "0.4.0",
-     elixir: "~> 1.9",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps(),
-     dialyzer: [plt_add_apps: [:mime, :phoenix, :plug]],
-     package: package(),
-     preferred_cli_env: [
-       coveralls: :test,
-       "coveralls.detail": :test,
-       "coveralls.html": :test,
-       "coveralls.post": :test,
-       "coveralls.travis": :test
+    [
+      app: :versionary,
+      name: "Versionary",
+      version: @version,
+      elixir: "~> 1.9",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      docs: docs(),
+      package: package(),
+      preferred_cli_env: [
+        dialyzer: [plt_add_apps: [:mime, :phoenix, :plug]],
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.html": :test,
+        "coveralls.post": :test,
+        "coveralls.travis": :test
       ],
-     test_coverage: [tool: ExCoveralls]]
+      test_coverage: [tool: ExCoveralls]
+    ]
   end
 
   def application do
@@ -31,20 +36,36 @@ defmodule Versionary.Mixfile do
       {:mime, "~> 1.3"},
       {:plug, "~> 1.3"},
       # dev
-      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       # test
       {:excoveralls, "~> 0.11", only: :test, runtime: false},
-      {:phoenix,     ">= 1.2.0", only: :test},
+      {:phoenix, ">= 1.2.0", only: :test},
       # dev/test
       {:dialyxir, "~> 1.1.0", only: [:dev, :test], runtime: false}
     ]
   end
 
   defp package do
-    [maintainers: ["Anthony Smith"],
-     licenses: ["MIT"],
-     links: %{
-       GitHub: "https://github.com/sticksnleaves/versionary"
-      }]
+    [
+      description: "Elixir plug for handling API versioning",
+      maintainers: ["Anthony Smith"],
+      licenses: ["MIT"],
+      links: %{
+        GitHub: @source_url
+      }
+    ]
+  end
+
+  defp docs do
+    [
+      extras: [
+        "LICENSE.md": [title: "License"],
+        "README.md": [title: "Overview"]
+      ],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: "#v{@version}",
+      formatters: ["html"]
+    ]
   end
 end


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the source of truth for this Elixir
library and leverage on latest features of ExDoc.